### PR TITLE
only update indicator icon if it has changed

### DIFF
--- a/data/plugins/indicator_plugin.py
+++ b/data/plugins/indicator_plugin.py
@@ -13,6 +13,7 @@ from tomate.ui import Systray
 
 logger = logging.getLogger(__name__)
 
+import functools
 
 class IndicatorPlugin(plugin.Plugin):
     @suppress_errors
@@ -51,6 +52,12 @@ class IndicatorPlugin(plugin.Plugin):
     @on(Events.TIMER_UPDATE)
     def update_icon(self, payload: TimerPayload):
         icon_name = self.icon_name_for(payload.elapsed_percent)
+        self._update_icon(icon_name)
+        logger.debug("action=update_icon pct=%f", payload.elapsed_percent)
+
+    # LRU_cache size of one means only new icon names will result in an indicator icon update.
+    @functools.lru_cache(maxsize=1)
+    def _update_icon(self, icon_name: str):
         self.indicator.set_properties(icon_name=icon_name)
         logger.debug("action=set_icon name=%s", icon_name)
 


### PR DESCRIPTION
Hey,
Here's a funny/frustrating one - I'm finding Gnome Shell CPU use to be higher than expected (`top` says `30%` of one core) with the indicator enabled. Now, this isn't your fault at all, you should 100% be able to expect that if you send the same icon location to an indicator every second then it should be a no-op. However, somewhere in the AppIndicator extension or Gnome Shell itself, this is causing unreasonable CPU use.

As a workaround for these bugs in other people's projects, here's a quick change to not send an update if the icon hasn't changed :) For me, this takes Gnome Shell CPU use from 30% to around 15% (for a 25min Pomodoro session)